### PR TITLE
Linking the domain name with the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,20 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="vitemadose.covidtracker.fr" />
+            </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="vitemadose.app" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
I created the intent filters to link the website to the app.
That way, if the app is installed on the device, a click on the website of ViteMaDose will open the app. Also, a little banner will be shown on the website to install the app.

See https://developer.android.com/training/app-links/verify-site-associations for more details.