### PR TITLE
Couleur d'arrière-plan en mode sombre

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -15,7 +15,7 @@
 
         <item name="separatorColor">@color/silver</item>
         <item name="iconTintColor">@color/grey_5</item>
-        <item name="backgroundColor">@color/black</item>
+        <item name="backgroundColor">@color/dark_grey_red</item>
         <item name="backgroundCardColor">#3a3a3a</item>
         <item name="backgroundCardColorSecondary">#3a3a3a</item>
     </style>

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -7,7 +7,7 @@
         <item name="android:textColorTertiary">@color/silver</item>
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/corail_dark</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorOnPrimary">@color/dark_grey_red</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">@color/corail_dark</item>
         <!-- Customize your theme here. -->

--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -7,7 +7,7 @@
         <item name="android:textColorTertiary">@color/silver</item>
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/corail_dark</item>
-        <item name="colorOnPrimary">@color/dark_grey_red</item>
+        <item name="colorOnPrimary">@color/thunder</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">@color/corail_dark</item>
         <!-- Customize your theme here. -->
@@ -15,7 +15,7 @@
 
         <item name="separatorColor">@color/silver</item>
         <item name="iconTintColor">@color/grey_5</item>
-        <item name="backgroundColor">@color/dark_grey_red</item>
+        <item name="backgroundColor">@color/thunder</item>
         <item name="backgroundCardColor">#3a3a3a</item>
         <item name="backgroundCardColorSecondary">#3a3a3a</item>
     </style>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,6 +10,7 @@
     <color name="corail_dark">#bc3f48</color>
     <color name="mine_shaft">#252525</color>
     <color name="scorpion">#5E5E5E</color>
+    <color name="dark_grey_red">#211E1F</color>
 
     <color name="grey_2">#F3F3F3</color>
     <color name="grey_3">#ECECEC</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,7 +10,7 @@
     <color name="corail_dark">#bc3f48</color>
     <color name="mine_shaft">#252525</color>
     <color name="scorpion">#5E5E5E</color>
-    <color name="dark_grey_red">#211E1F</color>
+    <color name="thunder">#211E1F</color>
 
     <color name="grey_2">#F3F3F3</color>
     <color name="grey_3">#ECECEC</color>


### PR DESCRIPTION
La couleur d'arrière-plan en mode sombre est pour le moment en noir uni (`#000000`).  
La faire tirer un peu plus vers un gris avec une légère teinte de rouge aurait un meilleur rendu à mon sens.  
Avant :  
![image](https://user-images.githubusercontent.com/45711398/115790946-defeec00-a3c7-11eb-954b-e592dc8da260.png)
  
Après :  
![image](https://user-images.githubusercontent.com/45711398/115790992-f3db7f80-a3c7-11eb-985d-1ba534c2b219.png)
