### PR TITLE
fix : improve a11y of center list

### DIFF
--- a/app/src/main/java/com/cvtracker/vmd/custom/view_holder/CenterViewHolder.kt
+++ b/app/src/main/java/com/cvtracker/vmd/custom/view_holder/CenterViewHolder.kt
@@ -2,28 +2,22 @@ package com.cvtracker.vmd.custom.view_holder
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Context.ACCESSIBILITY_SERVICE
 import android.content.res.ColorStateList
 import android.view.View
 import android.view.ViewGroup
-import android.view.accessibility.AccessibilityManager
 import com.cvtracker.vmd.R
 import com.cvtracker.vmd.custom.CenterAdapter
 import com.cvtracker.vmd.data.Bookmark
 import com.cvtracker.vmd.data.DisplayItem
-import com.cvtracker.vmd.extensions.color
-import com.cvtracker.vmd.extensions.colorAttr
-import com.cvtracker.vmd.extensions.hide
-import com.cvtracker.vmd.extensions.show
+import com.cvtracker.vmd.extensions.*
 import com.cvtracker.vmd.util.isTalkbackEnabled
 import kotlinx.android.synthetic.main.item_center.view.*
 
-
 class CenterViewHolder(
-        context: Context,
-        parent: ViewGroup,
-        adapter: CenterAdapter,
-        private val listener: Listener?
+    context: Context,
+    parent: ViewGroup,
+    adapter: CenterAdapter,
+    private val listener: Listener?
 ) : AbstractViewHolder<DisplayItem.Center>(context, parent, adapter, R.layout.item_center) {
 
     interface Listener {
@@ -96,19 +90,19 @@ class CenterViewHolder(
             } else ""
 
             bookmarkView.setCompoundDrawablesRelativeWithIntrinsicBounds(0, 0,
-                    when (center.bookmark) {
-                        Bookmark.NOTIFICATION_CHRONODOSE -> R.drawable.ic_lightning_charge_fill_24dp
-                        Bookmark.NOTIFICATION -> R.drawable.ic_notifications_24dp
-                        Bookmark.FAVORITE -> R.drawable.ic_bookmark_24dp
-                        else -> R.drawable.ic_bookmark_border_24_dp
-                    }, 0)
+                when (center.bookmark) {
+                    Bookmark.NOTIFICATION_CHRONODOSE -> R.drawable.ic_lightning_charge_fill_24dp
+                    Bookmark.NOTIFICATION -> R.drawable.ic_notifications_24dp
+                    Bookmark.FAVORITE -> R.drawable.ic_bookmark_24dp
+                    else -> R.drawable.ic_bookmark_border_24_dp
+                }, 0)
             bookmarkView.setText(
-                    when {
-                        center.available -> R.string.empty_string
-                        center.bookmark == Bookmark.NOTIFICATION_CHRONODOSE -> R.string.notifications_chronodose_activated
-                        center.bookmark == Bookmark.NOTIFICATION -> R.string.notifications_activated
-                        else -> R.string.activate_notifs
-                    }
+                when {
+                    center.available -> R.string.empty_string
+                    center.bookmark == Bookmark.NOTIFICATION_CHRONODOSE -> R.string.notifications_chronodose_activated
+                    center.bookmark == Bookmark.NOTIFICATION -> R.string.notifications_activated
+                    else -> R.string.activate_notifs
+                }
             )
 
             if (center.available && center.isValidAppointmentByPhoneOnly) {

--- a/app/src/main/java/com/cvtracker/vmd/custom/view_holder/CenterViewHolder.kt
+++ b/app/src/main/java/com/cvtracker/vmd/custom/view_holder/CenterViewHolder.kt
@@ -15,6 +15,7 @@ import com.cvtracker.vmd.extensions.color
 import com.cvtracker.vmd.extensions.colorAttr
 import com.cvtracker.vmd.extensions.hide
 import com.cvtracker.vmd.extensions.show
+import com.cvtracker.vmd.util.isTalkbackEnabled
 import kotlinx.android.synthetic.main.item_center.view.*
 
 
@@ -149,9 +150,7 @@ class CenterViewHolder(
                     position
                 }
 
-                val am = context.getSystemService(ACCESSIBILITY_SERVICE) as AccessibilityManager
-                val isExploreByTouchEnabled: Boolean = am.isTouchExplorationEnabled
-                if(isExploreByTouchEnabled){
+                if(context.isTalkbackEnabled()){
                     updateAppointmentCardUI(position, center)
                 } else {
                     adapter.notifyItemChanged(position)

--- a/app/src/main/java/com/cvtracker/vmd/custom/view_holder/StatisticsHeaderViewHolder.kt
+++ b/app/src/main/java/com/cvtracker/vmd/custom/view_holder/StatisticsHeaderViewHolder.kt
@@ -8,6 +8,7 @@ import com.cvtracker.vmd.data.DisplayItem
 import com.cvtracker.vmd.data.ItemStat
 import com.cvtracker.vmd.extensions.color
 import com.cvtracker.vmd.extensions.colorAttr
+import com.cvtracker.vmd.util.isTalkbackEnabled
 import kotlinx.android.synthetic.main.item_statistics_header.view.*
 
 class StatisticsHeaderViewHolder(
@@ -34,11 +35,13 @@ class StatisticsHeaderViewHolder(
                             color = color(R.color.danube)
                     )
             )
-            setOnClickListener {
-                data.isSlotFilterSelected = !data.isSlotFilterSelected
-                data.isChronodoseFilterSelected = false
-                adapter.notifyItemChanged(position)
-                listener?.onSlotsFilterClick()
+            if(!context.isTalkbackEnabled()) {
+                setOnClickListener {
+                    data.isSlotFilterSelected = !data.isSlotFilterSelected
+                    data.isChronodoseFilterSelected = false
+                    adapter.notifyItemChanged(position)
+                    listener?.onSlotsFilterClick()
+                }
             }
         }
         itemView.secondStatView.apply {
@@ -52,11 +55,13 @@ class StatisticsHeaderViewHolder(
                             color = colorAttr(R.attr.colorPrimary)
                     )
             )
-            setOnClickListener {
-                data.isChronodoseFilterSelected = !data.isChronodoseFilterSelected
-                data.isSlotFilterSelected = false
-                adapter.notifyItemChanged(position)
-                listener?.onChronodoseFilterClick()
+            if(!context.isTalkbackEnabled()) {
+                setOnClickListener {
+                    data.isChronodoseFilterSelected = !data.isChronodoseFilterSelected
+                    data.isSlotFilterSelected = false
+                    adapter.notifyItemChanged(position)
+                    listener?.onChronodoseFilterClick()
+                }
             }
         }
     }

--- a/app/src/main/java/com/cvtracker/vmd/util/AccessibilityHelper.kt
+++ b/app/src/main/java/com/cvtracker/vmd/util/AccessibilityHelper.kt
@@ -1,0 +1,9 @@
+package com.cvtracker.vmd.util
+
+import android.content.Context
+import android.view.accessibility.AccessibilityManager
+
+fun Context.isTalkbackEnabled(): Boolean {
+    val am = this.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    return am.isTouchExplorationEnabled
+}

--- a/app/src/main/res/layout/item_last_updated.xml
+++ b/app/src/main/res/layout/item_last_updated.xml
@@ -61,7 +61,8 @@
                 app:tint="@color/crete"
                 app:srcCompat="@drawable/ic_cancel_black_24dp"
                 android:background="?attr/selectableItemBackgroundBorderless"
-                android:contentDescription="@string/a11y_hide_disclaimer_message"/>
+                android:contentDescription="@string/a11y_hide_disclaimer_message"
+                android:importantForAccessibility="no"/>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/item_statistics_header.xml
+++ b/app/src/main/res/layout/item_statistics_header.xml
@@ -2,19 +2,22 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:importantForAccessibility="yes">
 
     <com.cvtracker.vmd.custom.StatView
         android:id="@+id/firstStatView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="10dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:importantForAccessibility="no"/>
 
     <com.cvtracker.vmd.custom.StatView
         android:id="@+id/secondStatView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="10dp"
-        android:layout_weight="1" />
+        android:layout_weight="1"
+        android:importantForAccessibility="no"/>
 </LinearLayout>


### PR DESCRIPTION
 improve a11y of center list by disabling for the moment items that triggers a notifyDataSetChange and loose the focus of the list.
For example the user cannot hide the alert info about last update because it's easier to disable the focus on this secondary feature than setting the focus on the next element in the list when this row disappear on click.
Same idea for the StatsView on the next row of the center list, the user can focus on it, and gets all the stats info at once, but he cannot use it to filter the result list for the same reason (harder to set focus on right next item when list has finish reload) and the user can still use the filter to do that so I think the UX remains ok.