### PR TITLE
Introduce Android shortcut

### DIFF
--- a/app/src/dev/res/xml/shortcuts.xml
+++ b/app/src/dev/res/xml/shortcuts.xml
@@ -2,17 +2,17 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
 
     <shortcut
-        android:shortcutId="bookmark"
         android:enabled="true"
         android:icon="@mipmap/ic_launcher"
-        android:shortcutShortLabel="@string/bookmark"
-        android:shortcutLongLabel="@string/bookmark">
+        android:shortcutId="bookmark"
+        android:shortcutLongLabel="@string/bookmark"
+        android:shortcutShortLabel="@string/bookmark">
 
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.cvtracker.vmd2.dev"
-            android:targetClass="com.cvtracker.vmd.bookmark.BookmarkActivity"
-            android:data="cvtrackervmd://bookmark" />
+            android:data="https://vitemadose.covidtracker.fr/bookmarks"
+            android:targetClass="com.cvtracker.vmd.home.MainActivity"
+            android:targetPackage="com.cvtracker.vmd2.dev" />
 
     </shortcut>
 

--- a/app/src/dev/res/xml/shortcuts.xml
+++ b/app/src/dev/res/xml/shortcuts.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="bookmark"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/bookmark"
+        android:shortcutLongLabel="@string/bookmark">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.cvtracker.vmd2.dev"
+            android:targetClass="com.cvtracker.vmd.bookmark.BookmarkActivity"
+            android:data="cvtrackervmd://bookmark" />
+
+    </shortcut>
+
+</shortcuts>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
                 <data android:pathPattern="/bookmark/.*/.*/.*/.*" />
             </intent-filter>
 
+            <meta-data android:name="android.app.shortcuts" android:resource="@xml/shortcuts" />
         </activity>
 
         <activity

--- a/app/src/prod/res/xml/shortcuts.xml
+++ b/app/src/prod/res/xml/shortcuts.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <shortcut
+        android:shortcutId="bookmark"
+        android:enabled="true"
+        android:icon="@mipmap/ic_launcher"
+        android:shortcutShortLabel="@string/bookmark"
+        android:shortcutLongLabel="@string/bookmark">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetPackage="com.cvtracker.vmd2"
+            android:targetClass="com.cvtracker.vmd.bookmark.BookmarkActivity"
+            android:data="cvtrackervmd://bookmark" />
+
+    </shortcut>
+
+</shortcuts>

--- a/app/src/prod/res/xml/shortcuts.xml
+++ b/app/src/prod/res/xml/shortcuts.xml
@@ -2,17 +2,17 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
 
     <shortcut
-        android:shortcutId="bookmark"
         android:enabled="true"
         android:icon="@mipmap/ic_launcher"
-        android:shortcutShortLabel="@string/bookmark"
-        android:shortcutLongLabel="@string/bookmark">
+        android:shortcutId="bookmark"
+        android:shortcutLongLabel="@string/bookmark"
+        android:shortcutShortLabel="@string/bookmark">
 
         <intent
             android:action="android.intent.action.VIEW"
-            android:targetPackage="com.cvtracker.vmd2"
-            android:targetClass="com.cvtracker.vmd.bookmark.BookmarkActivity"
-            android:data="cvtrackervmd://bookmark" />
+            android:data="https://vitemadose.covidtracker.fr/bookmarks"
+            android:targetClass="com.cvtracker.vmd.home.MainActivity"
+            android:targetPackage="com.cvtracker.vmd2" />
 
     </shortcut>
 


### PR DESCRIPTION
Small shortcut to `bookmarks` screen.

Usually available by longpressing launcher icon, it can be used to generate an alternative launcher icon.

![image](https://user-images.githubusercontent.com/4005409/118897127-f7502100-b909-11eb-84e9-70e149c2ceb2.png)