### PR TITLE
use CoroutineScope in presenter instead of GlobalScope

### DIFF
--- a/app/src/main/java/com/cvtracker/vmd/about/AboutPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/about/AboutPresenter.kt
@@ -2,15 +2,18 @@ package com.cvtracker.vmd.about
 
 import com.cvtracker.vmd.data.DisplayStat
 import com.cvtracker.vmd.master.DataManager
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import kotlin.coroutines.CoroutineContext
 
-class AboutPresenter(private val view: AboutContract.View) : AboutContract.Presenter {
+class AboutPresenter(private val view: AboutContract.View) : AboutContract.Presenter, CoroutineScope {
+    override val coroutineContext: CoroutineContext = Dispatchers.Main + Job()
 
     override fun loadStats() {
-        GlobalScope.launch(Dispatchers.Main) {
+        launch(Dispatchers.Main) {
             try {
                 view.showStats(DisplayStat.from(DataManager.getStats()))
             } catch (e: Exception) {

--- a/app/src/main/java/com/cvtracker/vmd/base/AbstractCenterPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/base/AbstractCenterPresenter.kt
@@ -6,8 +6,13 @@ import com.cvtracker.vmd.master.AnalyticsHelper
 import com.cvtracker.vmd.master.FcmHelper
 import com.cvtracker.vmd.master.PrefHelper
 import com.cvtracker.vmd.master.SortType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.CoroutineContext
 
-abstract class AbstractCenterPresenter(open val view: CenterContract.View): CenterContract.Presenter {
+abstract class AbstractCenterPresenter(open val view: CenterContract.View) : CenterContract.Presenter, CoroutineScope {
+    override val coroutineContext: CoroutineContext = Dispatchers.Main + SupervisorJob()
 
     override fun onCenterClicked(center: DisplayItem.Center) {
         view.openLink(center.url)

--- a/app/src/main/java/com/cvtracker/vmd/bookmark/BookmarkPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/bookmark/BookmarkPresenter.kt
@@ -8,13 +8,17 @@ import com.cvtracker.vmd.master.PrefHelper
 import com.cvtracker.vmd.master.SortType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class BookmarkPresenter(override val view: BookmarkContract.View) : AbstractCenterPresenter(view), BookmarkContract.Presenter {
 
+    private var jobBookmarks: Job? = null
+
     override fun loadBookmarks(department: String?, centerId: String?) {
-        launch(Dispatchers.Main) {
+        jobBookmarks?.cancel()
+        jobBookmarks = launch(Dispatchers.Main) {
             val centersBookmark = PrefHelper.centersBookmark
                     .filter { department == null || department == it.department }
                     .filter { centerId == null || centerId == it.centerId }

--- a/app/src/main/java/com/cvtracker/vmd/bookmark/BookmarkPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/bookmark/BookmarkPresenter.kt
@@ -6,16 +6,15 @@ import com.cvtracker.vmd.data.DisplayItem
 import com.cvtracker.vmd.master.DataManager
 import com.cvtracker.vmd.master.PrefHelper
 import com.cvtracker.vmd.master.SortType
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class BookmarkPresenter(override val view: BookmarkContract.View) : AbstractCenterPresenter(view), BookmarkContract.Presenter {
 
-    private var jobBookmarks: Job? = null
-
     override fun loadBookmarks(department: String?, centerId: String?) {
-        jobBookmarks?.cancel()
-        jobBookmarks = GlobalScope.launch(Dispatchers.Main) {
+        launch(Dispatchers.Main) {
             val centersBookmark = PrefHelper.centersBookmark
                     .filter { department == null || department == it.department }
                     .filter { centerId == null || centerId == it.centerId }

--- a/app/src/main/java/com/cvtracker/vmd/home/MainPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/home/MainPresenter.kt
@@ -10,14 +10,14 @@ import com.cvtracker.vmd.master.*
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_AVAILABLE_ID
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_CHRONODOSE_ID
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_VACCINE_TYPE_SECTION
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.*
 
 class MainPresenter(override val view: MainContract.View) : AbstractCenterPresenter(view), MainContract.Presenter {
-
-    private var jobSearch: Job? = null
-    private var jobCenters: Job? = null
 
     private var filterSections = FilterType.getDefault(PrefHelper.filters)
 
@@ -36,8 +36,7 @@ class MainPresenter(override val view: MainContract.View) : AbstractCenterPresen
     }
 
     override fun loadCenters() {
-        jobCenters?.cancel()
-        jobCenters = GlobalScope.launch(Dispatchers.Main) {
+        launch(Dispatchers.Main) {
             PrefHelper.favEntry?.let { entry ->
                 try {
                     val sortType = PrefHelper.primarySort
@@ -164,13 +163,12 @@ class MainPresenter(override val view: MainContract.View) : AbstractCenterPresen
     }
 
     override fun onSearchUpdated(search: String) {
-        jobSearch?.cancel()
         if (search.length < 2) {
             /** reset entry list **/
             view.setupSelector(emptyList())
             return
         }
-        jobSearch = GlobalScope.launch(Dispatchers.Main) {
+        launch(Dispatchers.Main) {
             /** Wait a bit then we are sure the user want to do this one **/
             delay(250)
             val list = mutableListOf<SearchEntry>()

--- a/app/src/main/java/com/cvtracker/vmd/home/MainPresenter.kt
+++ b/app/src/main/java/com/cvtracker/vmd/home/MainPresenter.kt
@@ -10,14 +10,14 @@ import com.cvtracker.vmd.master.*
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_AVAILABLE_ID
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_CHRONODOSE_ID
 import com.cvtracker.vmd.master.FilterType.Companion.FILTER_VACCINE_TYPE_SECTION
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.*
 import timber.log.Timber
 import java.util.*
 
 class MainPresenter(override val view: MainContract.View) : AbstractCenterPresenter(view), MainContract.Presenter {
+
+    private var jobSearch: Job? = null
+    private var jobCenters: Job? = null
 
     private var filterSections = FilterType.getDefault(PrefHelper.filters)
 
@@ -36,7 +36,8 @@ class MainPresenter(override val view: MainContract.View) : AbstractCenterPresen
     }
 
     override fun loadCenters() {
-        launch(Dispatchers.Main) {
+        jobCenters?.cancel()
+        jobCenters = launch(Dispatchers.Main) {
             PrefHelper.favEntry?.let { entry ->
                 try {
                     val sortType = PrefHelper.primarySort
@@ -163,12 +164,13 @@ class MainPresenter(override val view: MainContract.View) : AbstractCenterPresen
     }
 
     override fun onSearchUpdated(search: String) {
+        jobSearch?.cancel()
         if (search.length < 2) {
             /** reset entry list **/
             view.setupSelector(emptyList())
             return
         }
-        launch(Dispatchers.Main) {
+        jobSearch = launch(Dispatchers.Main) {
             /** Wait a bit then we are sure the user want to do this one **/
             delay(250)
             val list = mutableListOf<SearchEntry>()


### PR DESCRIPTION
we should use `CoroutineScope` when calling network requests instead of `GlobalScope`. It's not recommended by neither google nor kotlin team. The reference is here https://developer.android.com/kotlin/coroutines/coroutines-best-practices#global-scope


For more information, you can read from [this article](https://elizarov.medium.com/the-reason-to-avoid-globalscope-835337445abc) which was written by the maintener author of kotlin